### PR TITLE
Remove "slurm-" from image names

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_FRONTEND_IMAGE: ghcr.io/noaa-gsl/dockerspackstackslurmcluster/slurm-frontend
-  REGISTRY_MASTER_IMAGE: ghcr.io/noaa-gsl/dockerspackstackslurmcluster/slurm-master
-  REGISTRY_NODE_IMAGE: ghcr.io/noaa-gsl/dockerspackstackslurmcluster/slurm-node
+  REGISTRY_FRONTEND_IMAGE: ghcr.io/noaa-gsl/dockerspackstackslurmcluster/frontend
+  REGISTRY_MASTER_IMAGE: ghcr.io/noaa-gsl/dockerspackstackslurmcluster/master
+  REGISTRY_NODE_IMAGE: ghcr.io/noaa-gsl/dockerspackstackslurmcluster/node
   AWS_REGION: us-east-2
 
 jobs:

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -15,26 +15,26 @@ jobs:
       contents: read
     steps:
       -
-        name: Remove untagged versions of dockerspackstackslurmcluster/slurm-frontend
+        name: Remove untagged versions of dockerspackstackslurmcluster/frontend
         uses: actions/delete-package-versions@v5
         with: 
-          package-name: 'dockerspackstackslurmcluster/slurm-frontend'
+          package-name: 'dockerspackstackslurmcluster/frontend'
           package-type: 'container'
           min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
-        name: Remove untagged versions of dockerspackstackslurmcluster/slurm-master
+        name: Remove untagged versions of dockerspackstackslurmcluster/master
         uses: actions/delete-package-versions@v5
         with: 
-          package-name: 'dockerspackstackslurmcluster/slurm-master'
+          package-name: 'dockerspackstackslurmcluster/master'
           package-type: 'container'
           min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
       -
-        name: Remove untagged versions of dockerspackstackslurmcluster/slurm-node
+        name: Remove untagged versions of dockerspackstackslurmcluster/node
         uses: actions/delete-package-versions@v5
         with: 
-          package-name: 'dockerspackstackslurmcluster/slurm-node'
+          package-name: 'dockerspackstackslurmcluster/node'
           package-type: 'container'
           min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'


### PR DESCRIPTION
The image names for the containers inadvertently contains a "slurm-".  That is being corrected.