### PR TITLE
Refactor package-cleanup CI workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,7 +118,7 @@ jobs:
           UBUNTU_VERSION: ${{ matrix.ubuntu }}
           SLURM_VERSION: ${{ env.SLURM_VERSION }}
           SPACK_STACK_VERSION: ${{ env.SPACK_STACK_VERSION }}
-        run: docker compose -f docker-compose-test.yml up --pull never -d
+        run: docker compose -f docker-compose-test.yml up --pull never -d --wait
       -
         name: Check cluster logs
         run: docker compose -f docker-compose-test.yml logs
@@ -347,7 +347,7 @@ jobs:
           UBUNTU_VERSION: ${{ matrix.ubuntu }}
           SLURM_VERSION: ${{ env.SLURM_VERSION }}
           SPACK_STACK_VERSION: ${{ env.SPACK_STACK_VERSION }}
-        run: docker compose -f docker-compose-test.yml up --pull never -d
+        run: docker compose -f docker-compose-test.yml up --pull never -d --wait
       -
         name: Check cluster logs
         run: docker compose -f docker-compose-test.yml logs

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -1,6 +1,10 @@
 name: PackageCleanup
 
 on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       buildcache_cutoff:
@@ -12,104 +16,85 @@ on:
         required: false
         default: 'true'
 
+env:
+  # Must stay in sync with docker.yml. Used to construct per-(ubuntu, spack-stack)
+  # buildcache repo names for the cleanup-stale-buildcache job.
+  SPACK_STACK_VERSION: 2.1.0
+
 jobs:
-  cleanup-untagged:
+
+  # Remove untagged versions of our published images. New publishes leave the
+  # previous tagged versions as "untagged" if the tag was moved (e.g. when
+  # `latest` is re-pointed). Runs continuously to keep the registry tidy.
+  cleanup-packages:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
     permissions:
       packages: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        container: [frontend, master, node]
     steps:
       -
-        name: Remove untagged versions of dockerspackstackslurmcluster/slurm-spack-stack-frontend
+        name: Remove untagged versions of dockerspackstackslurmcluster/slurm-spack-stack-${{ matrix.container }}
         uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/slurm-spack-stack-frontend'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/slurm-spack-stack-master
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/slurm-spack-stack-master'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/slurm-spack-stack-node
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/slurm-spack-stack-node'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/frontend-cache-amd64
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/frontend-cache-amd64'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/frontend-cache-arm64
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/frontend-cache-arm64'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/master-cache-amd64
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/master-cache-amd64'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/master-cache-arm64
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/master-cache-arm64'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/node-cache-amd64
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/node-cache-amd64'
-          package-type: 'container'
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: 'true'
-      -
-        name: Remove untagged versions of dockerspackstackslurmcluster/node-cache-arm64
-        uses: actions/delete-package-versions@v5
-        with: 
-          package-name: 'dockerspackstackslurmcluster/node-cache-arm64'
+        with:
+          package-name: 'dockerspackstackslurmcluster/slurm-spack-stack-${{ matrix.container }}'
           package-type: 'container'
           min-versions-to-keep: 0
           delete-only-untagged-versions: 'true'
 
+  # Remove untagged versions of the docker layer caches written by CI. Each
+  # (container, ubuntu, arch) combination has its own cache package -- when CI
+  # pushes a new :cache tag, the previous version becomes untagged.
+  cleanup-caches:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        container: [frontend, master, node]
+        ubuntu: ['24.04', '26.04']
+        arch: [amd64, arm64]
+    steps:
+      -
+        name: Remove untagged versions of dockerspackstackslurmcluster/${{ matrix.container }}-cache-ubuntu-${{ matrix.ubuntu }}-${{ matrix.arch }}
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: 'dockerspackstackslurmcluster/${{ matrix.container }}-cache-ubuntu-${{ matrix.ubuntu }}-${{ matrix.arch }}'
+          package-type: 'container'
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: 'true'
+
+  # Age-based cleanup of stale spack OCI buildcache entries. Manual only (cutoff
+  # input is required) and parameterized so the operator can do dry runs first.
+  # One job per (ubuntu, spack-stack) cache repo, since each gets its own
+  # per-spec-hash blob/tag population from autopush.
   cleanup-stale-buildcache:
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.buildcache_cutoff != '' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu: ['24.04', '26.04']
     steps:
       -
-        name: Clean stale buildcache entries
+        name: Clean stale buildcache entries for ubuntu-${{ matrix.ubuntu }}-spack-stack-${{ env.SPACK_STACK_VERSION }}
         uses: actions/github-script@v7
         with:
           script: |
             const cutoff = new Date('${{ github.event.inputs.buildcache_cutoff }}');
             const dryRun = '${{ github.event.inputs.dry_run }}' === 'true';
             const org = 'noaa-gsl';
-            const packageName = 'dockerspackstackslurmcluster/buildcache';
+            const packageName = 'dockerspackstackslurmcluster/buildcache-ubuntu-${{ matrix.ubuntu }}-spack-stack-${{ env.SPACK_STACK_VERSION }}';
 
+            console.log(`Package: ${packageName}`);
             console.log(`Cutoff date: ${cutoff.toISOString()}`);
             console.log(`Dry run: ${dryRun}`);
 
@@ -164,4 +149,4 @@ jobs:
               page++;
             }
 
-            console.log(`\nSummary: ${deleted} ${dryRun ? 'would be ' : ''}deleted, ${kept} kept`);
+            console.log(`\nSummary for ${packageName}: ${deleted} ${dryRun ? 'would be ' : ''}deleted, ${kept} kept`);


### PR DESCRIPTION
This is a simplification of the CI package cleanup workflow.  A small bug fix for the main workflow is also added to ensure compose waits for all health checks when bringing up the cluster to run tests.